### PR TITLE
Inspect tree

### DIFF
--- a/after/plugin/treesitter.lua
+++ b/after/plugin/treesitter.lua
@@ -24,6 +24,12 @@ require("nvim-treesitter.configs").setup({
 		select = {
 			enable = true,
 			lookahead = true,
+			lsp_interop = {
+				enable = true,
+				border = "none",
+				floating_preview_opts = {},
+				peek_definition_code = { ["<leader>df"] = "@function.outer", ["<leader>dF"] = "@class.outer" },
+			},
 			keymaps = {
 				["af"] = "@function.outer",
 				["if"] = "@function.inner",
@@ -39,3 +45,5 @@ require("nvim-treesitter.configs").setup({
 	context_commentstring = { enable = true, enable_autocmd = false },
 	rainbow = { enable = true, extended_mode = true, max_file_lines = nil },
 })
+
+require("treesitter-context").setup({ mode = "topline" })

--- a/lua/user/packer.lua
+++ b/lua/user/packer.lua
@@ -77,7 +77,6 @@ return packer.startup(function(use)
 		"lvimuser/lsp-inlayhints.nvim",
 		"mrjones2014/nvim-ts-rainbow",
 		"nvim-treesitter/nvim-treesitter-textobjects",
-		"nvim-treesitter/playground",
 		{ "nvim-treesitter/nvim-treesitter", run = ":TSUpdate" },
 	})
 

--- a/lua/user/packer.lua
+++ b/lua/user/packer.lua
@@ -76,6 +76,7 @@ return packer.startup(function(use)
 		"JoosepAlviste/nvim-ts-context-commentstring",
 		"lvimuser/lsp-inlayhints.nvim",
 		"mrjones2014/nvim-ts-rainbow",
+		"nvim-treesitter/nvim-treesitter-context",
 		"nvim-treesitter/nvim-treesitter-textobjects",
 		{ "nvim-treesitter/nvim-treesitter", run = ":TSUpdate" },
 	})

--- a/lua/utils/no_format.lua
+++ b/lua/utils/no_format.lua
@@ -1,11 +1,15 @@
 return {
 	"",
 	"DiffviewFileHistory",
+	"NvimTree",
 	"checkhealth",
 	"dashboard",
+	"diffview",
 	"fugitive",
+	"fugitiveblame",
 	"git",
 	"help",
+	"log",
 	"lspinfo",
 	"mason",
 	"noice",
@@ -13,4 +17,6 @@ return {
 	"packer",
 	"qf",
 	"query",
+	"toggleterm",
+	"undotree",
 }

--- a/lua/utils/no_format.lua
+++ b/lua/utils/no_format.lua
@@ -12,5 +12,5 @@ return {
 	"notify",
 	"packer",
 	"qf",
-	"tsplayground",
+	"query",
 }


### PR DESCRIPTION
# Inspect tree

As of nvim version 0.9, `:InspectTree` does what ts-playground does natively

This PR:
- Removes treesitter-playground from package list
- Adds treesitter context
