### PR TITLE
Fix treesitter error

### DIFF
--- a/after/plugin/octo.lua
+++ b/after/plugin/octo.lua
@@ -1,4 +1,3 @@
 require("octo").setup({})
 
-local ft_to_parser = require("nvim-treesitter.parsers").filetype_to_parsername
-ft_to_parser.octo = "markdown"
+vim.treesitter.language.register("markdown", "octo")


### PR DESCRIPTION
this pr removes the error: `filetype_to_parsername is deprecated, please use 'vim.treesitter.language.register'` caused by Octo
fix found in [this comment](https://github.com/pwntester/octo.nvim/issues/374#issuecomment-1443817412)
