### PR TITLE
Eslint/Shellcheck fix

### DIFF
--- a/after/plugin/null-ls.lua
+++ b/after/plugin/null-ls.lua
@@ -54,7 +54,7 @@ null_ls.setup({
 		builtins_diagnostics.alex,
 		builtins_diagnostics.gitlint,
 		builtins_diagnostics.luacheck,
-		builtins_diagnostics.shellcheck.with({ extra_args = "-x" }),
+		builtins_diagnostics.shellcheck.with({ extra_args = { "-x" } }),
 		builtins_diagnostics.todo_comments,
 		builtins_diagnostics.vint,
 		builtins_diagnostics.yamllint.with({ extra_args = get_yamllint_args }),

--- a/lua/lsp_config/servers.lua
+++ b/lua/lsp_config/servers.lua
@@ -22,6 +22,7 @@ Servers.emmet_ls = {}
 
 Servers.eslint = {
 	root_dir = config_util.root_pattern(
+		".eslintrc",
 		".eslintrc.cjs",
 		".eslintrc.js",
 		".eslintrc.json",


### PR DESCRIPTION
- Fix shellcheck extra_args
- Look for eslintrc without suffix
    - this is not in the [docs](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats) but apparently is a valid file format
